### PR TITLE
feat(ide): add editorconfig to prevent formating conflicts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# This file is for unifying the coding style for different editors and IDEs
+# See editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "printWidth": 120,
   "trailingComma": "none",
   "arrowParens": "always"
 }


### PR DESCRIPTION
A `.editorconfig` is useful to prevent mismatching coding formations, like indentations.

These properties of the `.editorconfig` will be used by prettier automatically:
```
end_of_line
indent_style
indent_size/tab_width
max_line_length
```

They will override the Prettier options:
```
"endOfLine"
"useTabs"
"tabWidth"
"printWidth"
```