### PR TITLE
fix(userPayloadMapper return type)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastify-keycloak-adapter",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fastify-keycloak-adapter",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^7.4.0",

--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -92,7 +92,7 @@ const partialOptions = t.partial({
 const KeycloakOptions = t.intersection([requiredOptions, partialOptions])
 
 export type KeycloakOptions = t.TypeOf<typeof KeycloakOptions> & {
-  userPayloadMapper?: (userPayload: UserInfo) => {}
+  userPayloadMapper?: (userPayload: UserInfo) => any
   unauthorizedHandler?: (request: FastifyRequest, reply: FastifyReply) => void
 }
 


### PR DESCRIPTION
Change the `userPayloadMapper` return type from `{}` to `any`: otherwise it is not possible to return anything if `strict: true` inside `tsconfig.json`

If you don't like `any` as return type, we can think to write something like:

`userPayloadMapper?: <T>(userPayload: UserInfo) => T`