### PR TITLE
Update deprecated Request.routerPath reference

### DIFF
--- a/src/keycloak.ts
+++ b/src/keycloak.ts
@@ -317,7 +317,7 @@ export default fastifyPlugin(async (fastify: FastifyInstance, opts: KeycloakOpti
 
   const grantRoutes = ['/connect/:provider', '/connect/:provider/:override']
 
-  const isGrantRoute: (request: FastifyRequest) => boolean = (request) => grantRoutes.includes(request.routerPath)
+  const isGrantRoute: (request: FastifyRequest) => boolean = (request) => grantRoutes.includes(request.routeOptions.url)
 
   const userPayloadMapper = pipe(
     opts.userPayloadMapper,


### PR DESCRIPTION
Change reference of `request.routerPath` to `request.routeOptions.url` as noted in [Fastify Request docs](https://github.com/fastify/fastify/blob/main/docs/Reference/Request.md) to remove deprecation warning