### PR TITLE
feat: :sparkles: add a bypass fn in opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ server.register(keycloak, opts)
 
 - `unauthorizedHandler(request, reply)` is a function to customize the handling (e.g. the response) of unauthorized requests (optional)
 
+- `bypassFn(request)` is a function that returns true if you want to stop the normal authentication workflow and allow the request. It will prevent `userPayloadMapper` from being called and `fastify.session.user` from being generated.
+
 ## Configuration example
 
 ```typescript
@@ -131,6 +133,24 @@ const unauthorizedHandler = (request: FastifyRequest, reply: FastifyReply) => {
 const opts: KeycloakOptions = {
   // ...
   unauthorizedHandler: unauthorizedHandler
+}
+```
+
+## Set bypassFn
+
+Provides a function that returns true if you want to stop the normal authentication workflow and allow the request.
+
+```typescript
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { KeycloakOptions } from 'fastify-keycloak-adapter'
+
+const bypassFn = (request: FastifyRequest) => {
+  return Math.random() * 6 < 1 // russian roulette of security DO NOT USE IT !
+}
+
+const opts: KeycloakOptions = {
+  // ...
+  bypassFn: bypassFn
 }
 ```
 


### PR DESCRIPTION
As requested in #51 and cause I need it too.

Here is my proposal, a bypass function can be send in options, the function receive the request and return a boolean, if true prevent the authentication methods, if false let the flow goes as usual.

Let me know what you think before I start writing tests.